### PR TITLE
Add support for TVS-951X/N

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ TS-1264U|Q08R0|Q08X0|12/12 | ⚠️ See *2
 |TS-251D|Q04W1|QY570|2/2 |  
 |TS-653D|Q04O0|Q04N0|6/6 |  
 |TS-453D|Q04M0|QY581|4/4 | ⚠️ See 2
+|TVS-951N|SAN30|SBN10|9/9|
+|TVS-951X|Q0090|Q00A0|9/9|✅ Tested
 
 *1 Some or all disks LEDs are managed by other hardware (not the EC), if the model is missing 2 disks (e.g `8/10`), it's most likely the internal M.2/NVME ports that do not have an LED associated with them.\
 *2 Some or all of the disks do not have a present or error (green/red) LED.\

--- a/src/qnap8528.h
+++ b/src/qnap8528.h
@@ -1993,6 +1993,62 @@ static struct qnap8528_config qnap8528_configs[] = {
 		}
 	},
 	{
+		"TVS-951N", "SAN30", "SBN10",
+		{
+			.pwr_recovery   = 1,
+			.eup_mode       = 1,
+			.led_brightness = 1,
+			.led_status     = 1,
+			.led_10g        = 0,
+			.led_usb        = 1,
+			.led_jbod       = 0,
+			.led_ident      = 1,
+			.enc_serial_mb  = 0,
+			.vpd_bp_table   = 1,
+		},
+		.fans = (u8[]){ 1, 0},
+		.slots = (struct qnap8528_slot_config[]){
+			{ .name = "hdd1", .ec_index = 1, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd2", .ec_index = 2, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd3", .ec_index = 3, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd4", .ec_index = 4, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd5", .ec_index = 5, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd1", .ec_index = 6, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd2", .ec_index = 7, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd3", .ec_index = 8, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd4", .ec_index = 9, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ NULL }
+		}
+	},
+	{
+		"TVS-951X", "Q0090", "Q00A0",
+		{
+			.pwr_recovery   = 1,
+			.eup_mode       = 1,
+			.led_brightness = 1,
+			.led_status     = 1,
+			.led_10g        = 0,
+			.led_usb        = 1,
+			.led_jbod       = 0,
+			.led_ident      = 1,
+			.enc_serial_mb  = 0,
+			.vpd_bp_table   = 1,
+		},
+		.fans = (u8[]){ 1, 0},
+		.slots = (struct qnap8528_slot_config[]){
+			{ .name = "hdd1", .ec_index = 1, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd2", .ec_index = 2, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd3", .ec_index = 3, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd4", .ec_index = 4, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd5", .ec_index = 5, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd1", .ec_index = 6, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd2", .ec_index = 7, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd3", .ec_index = 8, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "ssd4", .ec_index = 9, .has_present = 1, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ NULL }
+		}
+	},
+	{
 		"TVS-H674T", "B6491", "Q0BK0",
 		.features = {
 			.led_brightness = 1,


### PR DESCRIPTION
Adds support for TVS-951X and TVS-951N. I have tested this on a TVS-951X and it works properly.

The changes are generated with _generate_config.py_ from configuration files extracted from the unit's DOM.

Before:

```console
[230059.061701] qnap8528 @ qnap8528_ec_hw_check: IT8528 EC device found successfully
[230060.184769] qnap8528 @ qnap8528_find_config: Searching configs for a match with MB=70-0Q0090150
[230060.184788] qnap8528 @ qnap8528_find_config: Could not find configuration for device, please report this issue
[230060.184808] qnap8528 qnap8528: probe with driver qnap8528 failed with error -524
[230060.184828] qnap8528 @ qnap8528_init: qnap8528 device driver failed to probe, unloading
[230084.059220] qnap8528 @ qnap8528_probe: Skipping HW check for IT8528
[230085.175428] qnap8528 @ qnap8528_find_config: Searching configs for a match with MB=70-0Q0090150
[230085.175446] qnap8528 @ qnap8528_find_config: Could not find configuration for device, please report this issue
[230085.175466] qnap8528 qnap8528: probe with driver qnap8528 failed with error -524
[230085.175486] qnap8528 @ qnap8528_init: qnap8528 device driver failed to probe, unloading
```

After:

```console
[233719.362942] qnap8528 @ qnap8528_ec_hw_check: IT8528 EC device found successfully
[233720.703292] qnap8528 @ qnap8528_find_config: Searching configs for a match with MB=70-0Q0090150
[233720.703307] qnap8528 @ qnap8528_find_config: Model MB code match found
[233720.703309] qnap8528 @ qnap8528_find_config: Model config requires BP match too
[233720.703311] qnap8528 @ qnap8528_find_config: Model BP code match found, device model is TVS-951X
[233720.703381] input: qnap8528 as /devices/platform/qnap8528/input/input9
[233720.703439] qnap8528 @ qnap8528_register_inputs: Buttons input device registered
[233720.703624] qnap8528 @ qnap8528_register_leds: LED devices registered
[233720.818403] qnap8528 @ qnap8528_register_hwmon: Hwmon device registered
```