### PR TITLE
Fix fan_pwm_set: clear override flag instead of locking at 100%

### DIFF
--- a/src/qnap8528.c
+++ b/src/qnap8528.c
@@ -945,7 +945,11 @@ static int qnap8528_fan_pwm_set(unsigned int fan, u8 value)
 		return -EINVAL;
 	}
 
-	ret = qnap8528_ec_write(reg_a, 0x10);
+	/* Clear the override flag (reg_a) before setting duty (reg_b).
+	 * Writing 0x10 to reg_a locks the fan zone at 100% duty permanently
+	 * until the next EC power cycle. Writing 0x00 clears the override
+	 * and allows the duty register (reg_b) to take effect. */
+	ret = qnap8528_ec_write(reg_a, 0x00);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
### Problem

`qnap8528_fan_pwm_set()` writes `0x10` to EC register `0x220` (case zone) or `0x223` (CPU zone) before setting the duty cycle. This value puts the IT8528 EC into a permanent 100% duty override mode that persists until the next power cycle.

Once any PWM value is written, fans are locked at maximum speed (~4000 RPM) and **cannot be reduced**, regardless of subsequent PWM writes.

### Root Cause

EC register `0x220`/`0x223` is a duty override flag:
- `0x10` = override active, fans run at 100% duty permanently
- `0x00` = override cleared, fan speed follows the duty register (`0x22E`/`0x24B`)

The original code always writes `0x10` (line 948 of `qnap8528.c`):
```c
ret = qnap8528_ec_write(reg_a, 0x10);  // locks fans at 100%
```

### Fix

Write `0x00` to clear the override instead:
```c
ret = qnap8528_ec_write(reg_a, 0x00);  // clears override, duty register takes effect
```

### Testing

Tested on QNAP TVS-1282T3 (BIOS QZ03AT05, IT8528 EC) running TrueNAS SCALE 25.10 (kernel 6.12.33):

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| Write PWM 80/255 | Fans: 4000+ RPM (stuck) | Fans: ~1800 RPM |
| Write PWM 40/255 | Fans: 4000+ RPM (stuck) | Fans: ~1100 RPM |
| Cycle PWM high->low | Never decreases | Responds correctly |

### Impact

This bug affects any user of the `qnap8528` module who writes to the fan PWM (either via `hwmon` sysfs or the built-in fan control thread). Fans become permanently stuck at full speed after the first write, defeating the purpose of fan control.