### PR TITLE
Add support for Qu605

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ TS-1264U|Q08R0|Q08X0|12/12 | ⚠️ See *2
 |BA-800|B6493|Q0AA0|10/10 |
 |BA-400|Q0BB1|Q0BL0|6/6 |
 |BA-600|B6493|Q0BK0|8/8 |
+|Qu605|SA1450|SB1360|4/8| ⚠️ See 2
 
 *1 Some or all disks LEDs are managed by other hardware (not the EC), if the model is missing 2 disks (e.g `8/10`), it's most likely the internal M.2/NVME ports that do not have an LED associated with them.\
 *2 Some or all of the disks do not have a present or error (green/red) LED.\

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Before installing, please check the *Supported Models* table and see that your d
 **Disclaimer:** This kernel module is provided as-is, without any warranty of functionality or fitness for a specific purpose. The developers of this kernel module accept no liability for any damage, data loss, or system instability resulting from its use, Use at your own risk .
 ### Install instructions using DKMS
 
-> **_⚠️ TR-464/TR-464xx/TS-253D Users:_**  It seems the device uses an ENE EC which does not return the correct chip ID, `skip_hw_check` needs to be set to true (`insmod qnap8528.ko skip_hw_check=true`), also, add this at the end of `ExecStart` in the service unit file.
+> **_⚠️ TR-464/TR-464xx/TS-253D/Qu-X05 Users:_**  It seems the device uses an ENE EC which does not return the correct chip ID, `skip_hw_check` needs to be set to true (`insmod qnap8528.ko skip_hw_check=true`), also, add this at the end of `ExecStart` in the service unit file.
 
 1. Download the latest release of the module from the [releases page](https://github.com/0xGiddi/tsx73a-ec/releases/latest) or clone the repository locally using `git clone https://github.com/0xgiddi/qnap8528.git`
 2. Extract the zip/tarball using `unzip <file>`, `tar xzf <file>`

--- a/src/qnap8528.h
+++ b/src/qnap8528.h
@@ -3918,6 +3918,33 @@ static struct qnap8528_config qnap8528_configs[] = {
             { NULL }
         }
     },
+	{
+        "QU605", "SA1450", "SB1360",
+        {
+            .pwr_recovery   = 0,
+            .eup_mode       = 0,
+            .led_brightness = 1,
+            .led_status     = 1,
+            .led_10g        = 0,
+            .led_usb        = 1,
+            .led_jbod       = 0,
+            .led_ident      = 0,
+            .enc_serial_mb  = 0,
+            .vpd_bp_table   = 3,
+        },
+        .fans = (u8[]){ 1, 2, 0},
+        .slots = (struct qnap8528_slot_config[]){
+			{ .name = "m2ssd1", .ec_index = 1, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "m2ssd2", .ec_index = 2, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd1", .ec_index = 3, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd2", .ec_index = 4, .has_present = 1, .has_active = 1, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd3", .ec_index = 5, .has_present = 0, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd4", .ec_index = 6, .has_present = 0, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd5", .ec_index = 7, .has_present = 0, .has_active = 0, .has_error = 1, .has_locate = 1},
+			{ .name = "hdd6", .ec_index = 8, .has_present = 0, .has_active = 0, .has_error = 1, .has_locate = 1},
+            { NULL }
+        }
+    },
 	
 
 	/* Here add models without BP code */


### PR DESCRIPTION
Add support for China-only model Qu605.
The config are generate from `QuX05_20260722-5.2.10.3568.img` initrd `model_SA1450_SB1360_10_10.conf`

However, unlike other model, Qu605 use **VPD table 3** in my test.

Before:
```
[65822.340669] qnap8528 @ qnap8528_probe: Skipping HW check for IT8528
[65823.462549] qnap8528 @ qnap8528_find_config: Searching configs for a match with MB=70006SA145001102RS
[65823.462571] qnap8528 @ qnap8528_find_config: Could not find configuration for device, please report this issue
[65823.462576] qnap8528 qnap8528: probe with driver qnap8528 failed with error -524
[65823.462592] qnap8528 @ qnap8528_init: qnap8528 device driver failed to probe, unloading
```
After:
```
[65899.075915] qnap8528 @ qnap8528_probe: Skipping HW check for IT8528
[65900.198161] qnap8528 @ qnap8528_find_config: Searching configs for a match with MB=70006SA145001102RS
[65900.198185] qnap8528 @ qnap8528_find_config: Model MB code match found
[65900.198187] qnap8528 @ qnap8528_find_config: Model config requires BP match too
[65900.198189] qnap8528 @ qnap8528_find_config: Model BP code match found, device model is QU605
[65900.198269] input: qnap8528 as /devices/platform/qnap8528/input/input28
[65900.198400] qnap8528 @ qnap8528_register_inputs: Buttons input device registered
[65900.198535] qnap8528 @ qnap8528_register_leds: LED devices registered
[65900.303295] qnap8528 @ qnap8528_register_hwmon: Hwmon device registered
```