### PR TITLE
Fixed KERNEL_DIR in dkms.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,7 +4,7 @@ AUTOINSTALL=yes
 BUILT_MODULE_NAME=qnap8528
 BUILT_MODULE_LOCATION=src/
 DEST_MODULE_LOCATION=/extra/qnap8528
-MAKE="make -C src/ KERNELDIR=/lib/modules/${kernelver}/build"
+MAKE="make -C src/ KERNEL_DIR=/lib/modules/${kernelver}/build"
 CLEAN="make -C src/ clean"
 
 


### PR DESCRIPTION
qnap8528.ko build with default $KERNEL_DIR in src/Makefile, which is current kernel version. Making vermagic mismatch when new kernel upgrade is install.